### PR TITLE
Bigc 747 highlight pipeline error

### DIFF
--- a/pipelines/shopgate.catalog.getProducts.v1.json
+++ b/pipelines/shopgate.catalog.getProducts.v1.json
@@ -12,11 +12,12 @@
       {"key": "sort", "id": "6", "optional": true},
       {"key": "productIds", "id": "7", "optional": true},
       {"key": "showInactive", "id": "15", "optional": true},
-      {"key": "characteristics", "id": "751", "optional": true}
+      {"key": "characteristics", "id": "20", "optional": true},
+      {"key": "skipHighlightLoading", "id": "30", "optional": true}
     ],
     "output": [
-      {"key": "totalProductCount", "id": "1000"},
-      {"key": "products", "id": "1001"}
+      {"key": "totalProductCount", "id": "100"},
+      {"key": "products", "id": "200"}
     ],
     "steps": [
       {
@@ -32,11 +33,12 @@
           {"key": "sort", "id": "6", "optional": true},
           {"key": "productIds", "id": "7", "optional": true},
           {"key": "showInactive", "id": "15", "optional": true},
-          {"key": "characteristics", "id": "751", "optional": true}
+          {"key": "characteristics", "id": "20", "optional": true},
+          {"key": "skipHighlightLoading", "id": "30", "optional": true}
         ],
         "output": [
-          {"key": "totalProductCount", "id": "1000"},
-          {"key": "products", "id": "1001"}
+          {"key": "totalProductCount", "id": "100"},
+          {"key": "products", "id": "200"}
         ]
       }
     ]

--- a/test/integration/extension/lib/steps/getProductsTest.js
+++ b/test/integration/extension/lib/steps/getProductsTest.js
@@ -30,16 +30,19 @@ describe('getProducts step > ', () => {
     it('Should return all products when it is not a getHighlight pipeline call', async () => {
       const result = await getProductsPipeline(context, input)
       assert.equal(result.products.length, input.productIds.length)
+      assert.equal(result.totalProductCount, input.productIds.length)
     })
     it('Should return no products when highligh returning is skipped', async () => {
       input.skipHighlightLoading = true
       const result = await getProductsPipeline(context, input)
       assert.equal(result.products.length, 0)
+      assert.equal(result.totalProductCount, 0)
     })
     it('Should return only highlight products', async () => {
       input.skipHighlightLoading = false
       const result = await getProductsPipeline(context, input)
       assert.equal(result.products.length, 3)
+      assert.equal(result.totalProductCount, 3)
       assert.equal(result.products[0].highlight, true)
     })
   })

--- a/test/integration/extension/lib/steps/getProductsTest.js
+++ b/test/integration/extension/lib/steps/getProductsTest.js
@@ -32,7 +32,7 @@ describe('getProducts step > ', () => {
       assert.equal(result.products.length, input.productIds.length)
       assert.equal(result.totalProductCount, input.productIds.length)
     })
-    it('Should return no products when highligh returning is skipped', async () => {
+    it('Should return no products when highlight returning is skipped', async () => {
       input.skipHighlightLoading = true
       const result = await getProductsPipeline(context, input)
       assert.equal(result.products.length, 0)

--- a/test/integration/extension/lib/steps/getProductsTest.js
+++ b/test/integration/extension/lib/steps/getProductsTest.js
@@ -1,0 +1,46 @@
+const assert = require('assert')
+const Credentials = require('../../../../../.integration-credentials.js')
+const getProductsPipeline = require('../../../../../extension/lib/steps/getProducts')
+
+/**
+ * These will fail if these products are removed from the system :)
+ */
+describe('getProducts step > ', () => {
+  const featuredProducts = ['69', '77', '97']
+  const context = {
+    config: {
+      clientId: Credentials.clientId,
+      accessToken: Credentials.accessToken,
+      storeHash: Credentials.storeHash
+    },
+    log: {
+      info: () => {},
+      error: () => {},
+      debug: () => {}
+    }
+  }
+  let input = {}
+  beforeEach(() => {
+    input = {
+      productIds: ['94', '87', '86', ...featuredProducts]
+    }
+  })
+
+  describe('Highlights > ', () => {
+    it('Should return all products when it is not a getHighlight pipeline call', async () => {
+      const result = await getProductsPipeline(context, input)
+      assert.equal(result.products.length, input.productIds.length)
+    })
+    it('Should return no products when highligh returning is skipped', async () => {
+      input.skipHighlightLoading = true
+      const result = await getProductsPipeline(context, input)
+      assert.equal(result.products.length, 0)
+    })
+    it('Should return only highlight products', async () => {
+      input.skipHighlightLoading = false
+      const result = await getProductsPipeline(context, input)
+      assert.equal(result.products.length, 3)
+      assert.equal(result.products[0].highlight, true)
+    })
+  })
+})


### PR DESCRIPTION
fixed the pipeline error by adding the logic that figured out which pipeline is calling the getProducts pipeline. Added integration tests to make sure things are returned properly depending on pipeline call and input provided.